### PR TITLE
changed adc sample rate.

### DIFF
--- a/ESP-SolMon.ino
+++ b/ESP-SolMon.ino
@@ -188,7 +188,7 @@ void setup() {
    *  ADS1115_475_SPS
    *  ADS1115_860_SPS
    */
-  adc.setConvRate(ADS1115_860_SPS); //uncomment if you want to change the default
+  adc.setConvRate(ADS1115_8_SPS); //uncomment if you want to change the default
 
   /* Set continuous or single shot mode:
    *


### PR DESCRIPTION
the sample duration was too short to get a reliable measurement.
samples are now taken at the lowest SPS value for maximum sample
time for single shot readings.